### PR TITLE
Fixed problems in CreditMemoApplyList & CreditMemoItemList to_record

### DIFF
--- a/lib/netsuite/records/credit_memo_apply_list.rb
+++ b/lib/netsuite/records/credit_memo_apply_list.rb
@@ -1,14 +1,21 @@
 module NetSuite
   module Records
     class CreditMemoApplyList
+      include Support::Fields
       include Namespaces::TranCust
 
+      fields :apply
+
       def initialize(attributes = {})
-        case attributes[:apply]
-        when Hash
-          applies << CreditMemoApply.new(attributes[:apply])
-        when Array
-          attributes[:apply].each { |apply| applies << CreditMemoApply.new(apply) }
+        initialize_from_attributes_hash(attributes)
+      end
+
+      def apply=(applies)
+        case applies
+          when Hash
+            self.applies << CreditMemoApply.new(applies)
+          when Array
+            applies.each { |apply| self.applies << CreditMemoApply.new(apply) }
         end
       end
 
@@ -17,11 +24,8 @@ module NetSuite
       end
 
       def to_record
-        applies.map do |apply|
-          { "#{record_namespace}:apply" => apply.to_record }
-        end
+        { "#{record_namespace}:apply" => applies.map(&:to_record) }
       end
-
     end
   end
 end

--- a/lib/netsuite/records/credit_memo_item_list.rb
+++ b/lib/netsuite/records/credit_memo_item_list.rb
@@ -1,14 +1,21 @@
 module NetSuite
   module Records
     class CreditMemoItemList
+      include Support::Fields
       include Namespaces::TranCust
 
+      fields :item
+
       def initialize(attributes = {})
-        case attributes[:item]
-        when Hash
-          items << CreditMemoItem.new(attributes[:item])
-        when Array
-          attributes[:item].each { |item| items << CreditMemoItem.new(item) }
+        initialize_from_attributes_hash(attributes)
+      end
+
+      def item=(items)
+        case items
+          when Hash
+            self.items << CreditMemoItem.new(items)
+          when Array
+            items.each { |item| self.items << CreditMemoItem.new(item) }
         end
       end
 
@@ -17,11 +24,8 @@ module NetSuite
       end
 
       def to_record
-        items.map do |item|
-          { "#{record_namespace}:item" => item.to_record }
-        end
+        { "#{record_namespace}:item" => items.map(&:to_record) }
       end
-
     end
   end
 end

--- a/spec/netsuite/records/credit_memo_apply_list_spec.rb
+++ b/spec/netsuite/records/credit_memo_apply_list_spec.rb
@@ -2,27 +2,24 @@ require 'spec_helper'
 
 describe NetSuite::Records::CreditMemoApplyList do
   let(:list) { NetSuite::Records::CreditMemoApplyList.new }
+  let(:apply) { NetSuite::Records::CreditMemoApply.new }
 
-  it 'has a applies attribute' do
-    expect(list.applies).to be_kind_of(Array)
+  it 'can have applies be added to it' do
+    list.applies << apply
+    apply_list = list.applies
+    expect(apply_list).to be_kind_of(Array)
+    expect(apply_list.length).to eql(1)
+    apply_list.each { |i| expect(i).to be_kind_of(NetSuite::Records::CreditMemoApply) }
   end
 
   describe '#to_record' do
-    before do
-      list.applies << NetSuite::Records::CreditMemoApply.new(
-        :job => 'something'
-      )
-    end
-
     it 'can represent itself as a SOAP record' do
-      record = [
-        {
-          'tranCust:apply' => {
-            'tranCust:job' => 'something'
-          }
-        }
-      ]
+      record = {
+          'tranCust:apply' => [{},{}]
+      }
+      list.applies.concat([apply, apply])
       expect(list.to_record).to eql(record)
     end
   end
+
 end

--- a/spec/netsuite/records/credit_memo_item_list_spec.rb
+++ b/spec/netsuite/records/credit_memo_item_list_spec.rb
@@ -2,27 +2,24 @@ require 'spec_helper'
 
 describe NetSuite::Records::CreditMemoItemList do
   let(:list) { NetSuite::Records::CreditMemoItemList.new }
+  let(:item) { NetSuite::Records::CreditMemoItem.new }
 
-  it 'has a items attribute' do
-    expect(list.items).to be_kind_of(Array)
+  it 'can have applies be added to it' do
+    list.items << item
+    item_list = list.items
+    expect(item_list).to be_kind_of(Array)
+    expect(item_list.length).to eql(1)
+    item_list.each { |i| expect(i).to be_kind_of(NetSuite::Records::CreditMemoItem) }
   end
 
   describe '#to_record' do
-    before do
-      list.items << NetSuite::Records::CreditMemoItem.new(
-        :rate => 10
-      )
-    end
-
     it 'can represent itself as a SOAP record' do
-      record = [
-        {
-          'tranCust:item' => {
-            'tranCust:rate' => 10
-          }
-        }
-      ]
+      record = {
+          'tranCust:item' => [{},{}]
+      }
+      list.items.concat([item, item])
       expect(list.to_record).to eql(record)
     end
   end
+
 end


### PR DESCRIPTION
The apply and item lists for a CreditMemo are not structured correctly in requests to NetSuite. This fix changes the format from:

```
<platformMsgs:record xsi:type="tranCust:CreditMemo" ...  >     
   <tranCust:applyList>
       <tranCust:apply>..</tranCust:apply>
   </tranCust:applyList>
   <tranCust:applyList>
       <tranCust:apply>..</tranCust:apply>
   </tranCust:applyList>
   ...
</platformMsgs:record>

to:

<platformMsgs:record xsi:type="tranCust:CreditMemo" ...  >     
   <tranCust:applyList>
       <tranCust:apply>..</tranCust:apply> 
       <tranCust:apply>..</tranCust:apply>
      ...
   </tranCust:applyList>
</platformMsgs:record>
```

@jeromecornet @emilienoel 
