### PR TITLE
Fixed CustomerRefundApplyList

### DIFF
--- a/lib/netsuite/records/customer_refund_apply_list.rb
+++ b/lib/netsuite/records/customer_refund_apply_list.rb
@@ -1,14 +1,21 @@
 module NetSuite
   module Records
     class CustomerRefundApplyList
+      include Support::Fields
       include Namespaces::TranCust
 
+      fields :apply
+
       def initialize(attributes = {})
-        case attributes[:apply]
-        when Hash
-          applies << CustomerRefundApply.new(attributes[:apply])
-        when Array
-          attributes[:apply].each { |apply| applies << CustomerRefundApply.new(apply) }
+        initialize_from_attributes_hash(attributes)
+      end
+
+      def apply=(applies)
+        case applies
+          when Hash
+            self.applies << CustomerRefundApply.new(applies)
+          when Array
+            applies.each { |apply| self.applies << CustomerRefundApply.new(apply) }
         end
       end
 
@@ -17,9 +24,7 @@ module NetSuite
       end
 
       def to_record
-        applies.map do |apply|
-          { "#{record_namespace}:apply" => apply.to_record }
-        end
+        { "#{record_namespace}:apply" => applies.map(&:to_record) }
       end
 
     end

--- a/spec/netsuite/records/customer_refund_apply_list_spec.rb
+++ b/spec/netsuite/records/customer_refund_apply_list_spec.rb
@@ -2,24 +2,22 @@ require 'spec_helper'
 
 describe NetSuite::Records::CustomerRefundApplyList do
   let(:list) { NetSuite::Records::CustomerRefundApplyList.new }
+  let(:apply) { NetSuite::Records::CustomerRefundApply.new }
 
-  it 'has a applies attribute' do
-    expect(list.applies).to be_kind_of(Array)
+  it 'can have applies be added to it' do
+    list.applies << apply
+    apply_list = list.applies
+    expect(apply_list).to be_kind_of(Array)
+    expect(apply_list.length).to eql(1)
+    apply_list.each { |i| expect(i).to be_kind_of(NetSuite::Records::CustomerRefundApply) }
   end
 
   describe '#to_record' do
-    before do
-      list.applies << NetSuite::Records::CustomerRefundApply.new(:amount => 10)
-    end
-
     it 'can represent itself as a SOAP record' do
-      record = [
-        {
-          'tranCust:apply' => {
-            'tranCust:amount' => 10
-          }
-        }
-      ]
+      record = {
+          'tranCust:apply' => [{},{}]
+      }
+      list.applies.concat([apply,apply])
       expect(list.to_record).to eql(record)
     end
   end


### PR DESCRIPTION
The apply and item lists for a CustomerRefund are not structured correctly in requests to NetSuite. This fix changes the format from:

```
<platformMsgs:record xsi:type="tranCust:CustomerRefund" ...  >     
   <tranCust:applyList>
       <tranCust:apply>..</tranCust:apply>
   </tranCust:applyList>
   <tranCust:applyList>
       <tranCust:apply>..</tranCust:apply>
   </tranCust:applyList>
   ...
</platformMsgs:record>

to:

<platformMsgs:record xsi:type="tranCust:CustomerRefund" ...  >     
   <tranCust:applyList>
       <tranCust:apply>..</tranCust:apply> 
       <tranCust:apply>..</tranCust:apply>
      ...
   </tranCust:applyList>
</platformMsgs:record>
```

@jeromecornet @emilienoel 
