### PR TITLE
Replace All option in Customer Payment Credit List

### DIFF
--- a/lib/netsuite/records/customer_payment_credit_list.rb
+++ b/lib/netsuite/records/customer_payment_credit_list.rb
@@ -1,32 +1,15 @@
 module NetSuite
   module Records
-    class CustomerPaymentCreditList
-      include Support::Fields
+    class CustomerPaymentCreditList < Support::Sublist
       include Namespaces::TranCust
 
-      fields :credit
+      sublist :credit, CustomerPaymentCredit
 
-      def initialize(attributes = {})
-        initialize_from_attributes_hash(attributes)
-      end
-
-      def credit=(credits)
-        case credits
-          when Hash
-            self.credits << CustomerPaymentCredit.new(credits)
-          when Array
-            credits.each { |credit| self.credits << CustomerPaymentCredit.new(credit) }
-        end
-      end
-
+      # for backward compatibility
       def credits
-        @credits ||= []
+        self.credit
       end
-
-      def to_record
-        { "#{record_namespace}:credit" => credits.map(&:to_record) }
-      end
-
     end
+
   end
 end


### PR DESCRIPTION
@prburke @jeromecornet 

I don't think we'll want to use replaceAll as true at all. Honestly, I don't really know what it means. I think you can't create a customer payment and apply some of the open credit memos to the payment but leave the rest as open (for another payment).

We need to add this change (or have a way to set replaceAll to false) because we need to change the way we create the customer payments. Currently we're using `initialize` and finding the invoices and credit memos from the list, but that doesn't allow us to choose the currency and defaults to the primary currency of the customer.

Only information I could find about `replaceAll`

> replaceAll Attribute Update
> The replaceAll attribute on lists has been updated in order to allow you to add or update a subset of items in a list without having to resubmit the entire list.
> This is only true for Keyed lists such as transaction line items. Items are added to the existing list when replaceAll is set to FALSE, and a list of new items is sent in the request. Items in a list are updated when replaceAll is set to FALSE and the Line Id is set for the items in the request. The default setting for the replaceAll attribute remains as TRUE.
> Previously, the replaceAll attribute always behaved as if it were TRUE regardless of the setting.
> http://www.netsuite.com/portal/partners/integration/includes/ReleaseNotesVersion2_5_0.html
